### PR TITLE
Limit python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     ],
     extras_require={
         "testing": [
-            "dj-database-url<1",  # 1.0.0 requires django > 3.2
+            "dj-database-url>=1,<2",
             "pytest>=7,<8",
             "factory-boy>=3,<4",
             "pytest-django>=4,<5",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ from setuptools import find_packages, setup
 
 from wagtail_helpdesk import __version__
 
-
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
@@ -23,6 +22,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     license="BSD",
+    python_requires=">=3.9",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
@@ -30,9 +30,8 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Framework :: Django",
         "Framework :: Django :: 3.2",
         "Framework :: Wagtail",
@@ -46,7 +45,7 @@ setup(
         "django-allauth>=0.44,<1.0",
         "django-crispy-forms>=1.0,<2.0",
         "python-gitlab>=2.0,<3.0",
-        "argon2-cffi>=21.0,<22.0"
+        "argon2-cffi>=21.0,<22.0",
     ],
     extras_require={
         "testing": [

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.7,3.8,3.9,3.10}-django{3.2}-wagtail{3.0,4.0,4.1,main}-{sqlite,postgres}
+    python{3.9,3.10}-django{3.2}-wagtail{3.0,4.0,4.1,main}-{sqlite,postgres}
     flake
 
 [flake8]
@@ -17,8 +17,6 @@ install_command = pip install -e ".[testing]" -U {opts} {packages}
 commands = pytest
 
 basepython =
-    python3.7: python3.7
-    python3.8: python3.8
     python3.9: python3.9
     python3.10: python3.10
 


### PR DESCRIPTION
No use in supporting older Python versions when no-one is running this code in production.